### PR TITLE
Fix audio session category options

### DIFF
--- a/InterviewHelperPOC/InterviewHelperPOCApp.swift
+++ b/InterviewHelperPOC/InterviewHelperPOCApp.swift
@@ -13,7 +13,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(.playAndRecord, options: .defaultToSpeaker)
+            try session.setCategory(.playAndRecord, options: [.defaultToSpeaker])
             try session.setActive(true)
         } catch {
             fatalError("AVAudioSession configuration error: \(error.localizedDescription)")

--- a/InterviewHelperPOC/InterviewHelperPOCApp.swift
+++ b/InterviewHelperPOC/InterviewHelperPOCApp.swift
@@ -13,7 +13,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(.playAndRecord, options: [.defaultToSpeaker])
+            try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .allowBluetooth])
             try session.setActive(true)
         } catch {
             fatalError("AVAudioSession configuration error: \(error.localizedDescription)")


### PR DESCRIPTION
This PR fixes the input parameter for the AudioSession `setCategory` method. In addition, the `allowBluetooth` option was added. 